### PR TITLE
Bump terraform version for updated gpg keys

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -29,7 +29,7 @@ var artifactsDir = @"./artifacts";
 var nugetVersion = string.Empty;
 var buildDir = @"./build";
 
-string terraformVersion = "0.11.8";
+string terraformVersion = "0.11.15";
 string awsPluginVersion = "1.39.0";
 string azurePluginVersion = "0.1.1";
 string azureRmPluginVersion = "1.17.0";


### PR DESCRIPTION
Hashicorp have rotated their gpg keys due to a [vulnerability](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512) and backported the changes to 0.11.x as part of 0.11.15. This PR bumps our tooling version to `0.11.15` to follow suite, otherwise terraform will be unable to download newer versions of providers with an error such as:

```
Error installing provider "aws": openpgp: signature made by unknown entity.
```